### PR TITLE
Don't start if server already started (from external)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Based on tern_for_vim and deoplete-jedi
 ## Important!
 
 If no .tern-project file is found in the current buffer's directory that is
-being edited or its ancestors, deoplete-ternjs will start the ternjs server 
+being edited or its ancestors, deoplete-ternjs will start the ternjs server
 in the current working directory:
 
 ```vim
@@ -46,6 +46,13 @@ Plug 'carlitux/deoplete-ternjs'
 " Use deoplete.
 let g:tern_request_timeout = 1
 let g:tern_show_signature_in_pum = 0  " This do disable full signature type on autocomplete
+```
+
+If you are using [tern_for_vim](https://github.com/ternjs/tern_for_vim), you also want to use the same tern command with deoplete-ternjs
+```vim
+" Use tern_for_vim.
+let g:tern#command = ["tern"]
+let g:tern#arguments = ["--persistent"]
 ```
 
 Also if you are using add loadEagerly - * many files * - this to your .bashrc or .zshrc, this will

--- a/rplugin/python3/deoplete/sources/ternjs.py
+++ b/rplugin/python3/deoplete/sources/ternjs.py
@@ -88,6 +88,11 @@ class Source(Base):
         self._search_tern_project_dir()
         env = None
 
+        portFile = os.path.join(self._project_directory, ".tern-port")
+        if os.path.isfile(portFile):
+            self.port = int(open(portFile, "r").read())
+            return
+
         if platform.system() == 'Darwin':
             env = os.environ.copy()
             env['PATH'] += ':/usr/local/bin'


### PR DESCRIPTION
Hi Carlitux,

Thank you for your excellent plugin, but I have an small issue when combine it with tern_for_vim:

After set tern_for_vim these options
let g:tern#command = ["tern"]
let g:tern#arguments = ["--persistent"]

I can make tern_for_vim use global tern like deoplete-ternjs
but when I start tern_for_vim (like go to difenation) before start complete, deoplete-ternjs start the 2nd tern server.
when deoplete-ternjs start first, tern_for_vim does not create the 2nd server, so I read the code of tern_for_vim and see how it check existing server, then include it.

Please pull if you feel it ok, thanks.

Cheers,
Binh