### PR TITLE
Configurable binary path

### DIFF
--- a/plugin/deoplete-ternjs.vim
+++ b/plugin/deoplete-ternjs.vim
@@ -1,0 +1,8 @@
+if exists('g:loaded_deoplete_ternjs')
+  finish
+endif
+
+let g:loaded_deoplete_ternjs = 1
+
+let g:deoplete#sources#ternjs#tern_bin = get(g:, 'deoplete#sources#ternjs#tern_bin', 'tern') 
+

--- a/rplugin/python3/deoplete/sources/ternjs.py
+++ b/rplugin/python3/deoplete/sources/ternjs.py
@@ -57,7 +57,7 @@ class Source(Base):
         self.proc = None
         self.last_failed = 0
         self.cached = {'row': -1, 'end': -1}
-        self._tern_command = 'tern'
+        self._tern_command = self.vim.vars['deoplete#sources#ternjs#tern_bin'] or 'tern'
         self._tern_arguments = '--persistent'
         self._tern_timeout = 1
         self._tern_show_signature = True


### PR DESCRIPTION
As discussed in #13 some people prefer a local installation of tern, the PR makes the path to the tern command configurable (solution taken from https://github.com/steelsojka/deoplete-flow)

For example the following changes the path to a local installation if it exists

```VimL
function! StrTrim(txt)
  return substitute(a:txt, '^\n*\s*\(.\{-}\)\n*\s*$', '\1', '')
endfunction

let g:tern_path = StrTrim(system('PATH=$(npm bin):$PATH && which tern'))
if g:tern_path != 'tern not found'
  let g:deoplete#sources#ternjs#tern_bin = g:tern_path
endif
```

Tested on macOS with nvim 0.1.5-dev
