### PR TITLE
Fix filetypes

### DIFF
--- a/rplugin/python3/deoplete/sources/ternjs.py
+++ b/rplugin/python3/deoplete/sources/ternjs.py
@@ -49,7 +49,9 @@ class Source(Base):
         self.mark = '[ternjs]'
         self.input_pattern = (r'\.\w*$|^\s*@\w*$|' + import_re)
         self.rank = 700
-        self.filetypes = ['javascript'].extend(self.vim.vars['tern#filetypes'])
+        self.filetypes = ['javascript']
+        if 'tern#filetypes' in vim.vars:
+            self.filetypes.extend(vim.vars['tern#filetypes'])
 
         self._project_directory = None
         self.port = None


### PR DESCRIPTION
ac16e2100b65b5c9b6937eb52da24d943bca6fe9 was causing deoplete-ternjs to show completions in all filetypes.  The problem is that `list.extend()` alters the list in place and doesn't return a value.