### PR TITLE
Fix error when destructor is called before on_init

### DIFF
--- a/rplugin/python3/deoplete/sources/ternjs.py
+++ b/rplugin/python3/deoplete/sources/ternjs.py
@@ -141,7 +141,8 @@ class Source(Base):
             self._do_nothing = True
 
     def __del__(self):
-        self.stop_server()
+        if self.is_initialized:
+            self.stop_server()
 
     def start_server(self):
         if not self._tern_command:


### PR DESCRIPTION
Prevents error when nvim is started within an nvim terminal window (e.g. `git commit --amend`)