### PR TITLE
Delete .tern-port file on exit. #66 workaround

### DIFF
--- a/autoload/ternjs.vim
+++ b/autoload/ternjs.vim
@@ -1,0 +1,18 @@
+if get(s:, 'loaded', 0)
+    finish
+endif
+let s:loaded = 1
+
+function! ternjs#Enable()
+endfunction
+
+augroup ternjs
+  autocmd!
+  autocmd VimLeavePre * call ternjs#deleteTernPort()
+augroup END
+
+function! ternjs#deleteTernPort()
+    if !empty(glob(join([getcwd(), ".tern-port"], "/")))
+        echo delete(fnameescape(join([getcwd(), ".tern-port"], "/"))) == 0 ? "Success" : "Fail"
+    endif
+endfunction

--- a/plugin/deoplete-ternjs.vim
+++ b/plugin/deoplete-ternjs.vim
@@ -4,7 +4,9 @@ endif
 
 let g:loaded_deoplete_ternjs = 1
 
-let g:deoplete#sources#ternjs#tern_bin = get(g:, 'deoplete#sources#ternjs#tern_bin', 'tern') 
+call ternjs#Enable()
+
+let g:deoplete#sources#ternjs#tern_bin = get(g:, 'deoplete#sources#ternjs#tern_bin', 'tern')
 
 if !exists('g:tern#filetypes')
 let g:tern#filetypes = [


### PR DESCRIPTION
It is workaround that deletes .tern-port file on vim exit. I would love to see real fix but I don't know how to fix this in deoplete.