### PR TITLE
Start tern service in vim plugin.

### DIFF
--- a/autoload/ternjs.vim
+++ b/autoload/ternjs.vim
@@ -3,16 +3,31 @@ if get(s:, 'loaded', 0)
 endif
 let s:loaded = 1
 
+let s:plug = expand("<sfile>:p:h:h")
+let s:script = s:plug . '/scripts/ternjs.py'
+if has('python3')
+    execute 'py3file ' . fnameescape(s:script)
+elseif has('python')
+    execute 'pyfile ' . fnameescape(s:script)
+endif
+
 function! ternjs#Enable()
+    if has('python3')
+        py3 tern_startServer()
+    elseif has('python')
+        py tern_startServer()
+    endif
 endfunction
 
 augroup ternjs
-  autocmd!
-  autocmd VimLeavePre * call ternjs#deleteTernPort()
+    autocmd!
+    autocmd VimLeavePre * call ternjs#killServer()
 augroup END
 
-function! ternjs#deleteTernPort()
-    if !empty(glob(join([getcwd(), ".tern-port"], "/")))
-        echo delete(fnameescape(join([getcwd(), ".tern-port"], "/"))) == 0 ? "Success" : "Fail"
+function! ternjs#killServer()
+    if has('python3')
+        py3 tern_killServers()
+    elseif has('python')
+        py tern_killServers()
     endif
 endfunction

--- a/scripts/ternjs.py
+++ b/scripts/ternjs.py
@@ -1,0 +1,42 @@
+import os
+import platform
+import subprocess
+
+import vim
+
+_tern_servers_by_path = {}
+
+
+def tern_startServer():
+    global _tern_servers_by_path
+
+    try:
+        tern_command = vim.eval('g:deoplete#sources#ternjs#tern_bin') or 'tern'
+    except vim.error:
+        tern_command = 'tern'
+
+    env = None
+
+    if platform.system() == 'Darwin':
+        env = os.environ.copy()
+        env['PATH'] += ':/usr/local/bin'
+
+    cwd = os.getcwd()
+
+    _tern_servers_by_path[cwd] = subprocess.Popen(
+        [tern_command, '--persistent'],
+        cwd=cwd,
+        shell=platform.system() == "Windows",
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def tern_killServer():
+    global _tern_servers_by_path
+    for proc in _tern_servers_by_path.values():
+        proc.stdin.close()
+        proc.wait()
+        proc = None


### PR DESCRIPTION
Currently tern is started in deoplete plugin. This fix starts and stops
tern service directly from vim plugin and deoplete plugin only expects
that tern server will be running.

WARNING: not tested with nvim
WARNING: I might be not aware of specific scenarios