### PR TITLE
Start tern process with --no-port-file option.

### DIFF
--- a/rplugin/python3/deoplete/sources/ternjs.py
+++ b/rplugin/python3/deoplete/sources/ternjs.py
@@ -167,7 +167,7 @@ class Source(Base):
             env['PATH'] += ':/usr/local/bin'
 
         self._proc = subprocess.Popen(
-            [self._tern_command, '--persistent'],
+            [self._tern_command, '--persistent', '--no-port-file'],
             cwd=self._project_directory,
             shell=is_window,
             env=env,


### PR DESCRIPTION
I just upgrade tern to 0.24.0 which supports "--no-port-file" option.
Then I upgrade ternjs.py by using that option, it works well for me.

